### PR TITLE
Switch to jupyterlab-contrib and PyPI

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/NERSC/{{ name|lower }}/archive/v{{ version }}.tar.gz
-  sha256: 6834e0502daf2cc883fb40dac4e85675e0854c9f89f139e508675165985bf2b8
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f60ea1c270689483175cf789d243c5f16c6bb73f7168dc23a4d8be93e3ed8d70
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
@@ -33,7 +33,7 @@ test:
     - python -m jupyterlab.browser_check  # [not linux]
 
 about:
-  home: https://github.com/NERSC/jupyterlab-favorites
+  home: https://github.com/jupyterlab-contrib/jupyterlab-favorites
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE


### PR DESCRIPTION
This will break downstream user as the package plugin had to change its id.